### PR TITLE
Add PWA SVG icon and help/guide page

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7,7 +7,7 @@
 html,
 body {
   height: 100%;
-  overflow: hidden;
+  overflow: auto;
 }
 
 body {

--- a/app/help/help.module.css
+++ b/app/help/help.module.css
@@ -1,0 +1,187 @@
+/* ── Help Page ── */
+
+.container {
+  max-width: 430px;
+  margin: 0 auto;
+  padding: 16px 20px 40px;
+  min-height: 100dvh;
+  animation: fadeUp 0.4s ease-out;
+}
+
+.header {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 24px;
+}
+
+.title {
+  font-family: var(--font-dm-serif), serif;
+  font-size: 1.5rem;
+  color: #22c55e;
+  letter-spacing: -0.5px;
+}
+
+.subtitle {
+  font-family: var(--font-outfit), sans-serif;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.35);
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+
+/* ── Sections ── */
+
+.section {
+  margin-bottom: 24px;
+}
+
+.sectionTitle {
+  font-family: var(--font-dm-serif), serif;
+  font-size: 1.15rem;
+  color: #22c55e;
+  margin-bottom: 10px;
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 18px 20px;
+}
+
+.text {
+  font-family: var(--font-outfit), sans-serif;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.65);
+  line-height: 1.7;
+}
+
+/* ── Steps ── */
+
+.steps {
+  font-family: var(--font-outfit), sans-serif;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.65);
+  line-height: 1.7;
+  padding-left: 20px;
+  margin: 12px 0 16px;
+}
+
+.steps li {
+  margin-bottom: 6px;
+}
+
+.steps strong {
+  color: #e8e8f0;
+}
+
+/* ── Rules ── */
+
+.ruleList {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.rule {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  font-family: var(--font-outfit), sans-serif;
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.55);
+  line-height: 1.6;
+}
+
+.rule strong {
+  color: #e8e8f0;
+}
+
+.ruleIcon {
+  font-size: 1rem;
+  line-height: 1.4;
+  flex-shrink: 0;
+}
+
+/* ── Tips ── */
+
+.tipList {
+  font-family: var(--font-outfit), sans-serif;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.65);
+  line-height: 1.7;
+  padding-left: 18px;
+  list-style: disc;
+}
+
+.tipList li {
+  margin-bottom: 10px;
+}
+
+.tipList strong {
+  color: #e8e8f0;
+}
+
+/* ── Game Modes ── */
+
+.modeItem {
+  margin-bottom: 14px;
+}
+
+.modeItem:last-child {
+  margin-bottom: 0;
+}
+
+.modeName {
+  font-family: var(--font-outfit), sans-serif;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #e8e8f0;
+  margin-bottom: 4px;
+}
+
+/* ── Back Button ── */
+
+.backRow {
+  display: flex;
+  justify-content: center;
+  margin-top: 8px;
+}
+
+.backBtn {
+  display: inline-block;
+  background: rgba(34, 197, 94, 0.15);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+  color: #22c55e;
+  padding: 12px 32px;
+  border-radius: 14px;
+  font-family: var(--font-outfit), sans-serif;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 1px;
+  text-decoration: none;
+  transition: all 0.2s;
+}
+
+.backBtn:hover {
+  background: rgba(34, 197, 94, 0.25);
+  color: #4ade80;
+}
+
+.backBtn:active {
+  transform: scale(0.96);
+}
+
+/* ── Animation ── */
+
+@keyframes fadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/app/help/page.js
+++ b/app/help/page.js
@@ -1,0 +1,145 @@
+"use client";
+
+import Link from "next/link";
+import styles from "./help.module.css";
+
+export default function HelpPage() {
+  return (
+    <div className={styles.container}>
+      <header className={styles.header}>
+        <h1 className={styles.title}>FlowGrid</h1>
+        <span className={styles.subtitle}>Guide</span>
+      </header>
+
+      {/* How to Play */}
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>How to Play</h2>
+        <div className={styles.card}>
+          <p className={styles.text}>
+            FlowGrid is a path-drawing puzzle. Each grid contains pairs of
+            colored dots. Your goal is to connect every matching pair with a
+            continuous path — and fill every cell on the board.
+          </p>
+          <ol className={styles.steps}>
+            <li>
+              <strong>Drag</strong> from any colored dot to start drawing a path.
+            </li>
+            <li>
+              <strong>Draw</strong> horizontally or vertically through empty cells
+              toward the matching dot of the same color.
+            </li>
+            <li>
+              <strong>Connect</strong> both dots of every color pair.
+            </li>
+            <li>
+              <strong>Fill</strong> every cell on the grid — no empty spaces
+              allowed.
+            </li>
+          </ol>
+          <div className={styles.ruleList}>
+            <div className={styles.rule}>
+              <span className={styles.ruleIcon} style={{ color: "#ef4444" }}>
+                &#x2716;
+              </span>
+              <span>
+                Paths cannot cross or overlap each other. Drawing through an
+                existing path will erase it.
+              </span>
+            </div>
+            <div className={styles.rule}>
+              <span className={styles.ruleIcon} style={{ color: "#22c55e" }}>
+                &#x21A9;
+              </span>
+              <span>
+                You can backtrack along your current path by dragging backward.
+              </span>
+            </div>
+            <div className={styles.rule}>
+              <span className={styles.ruleIcon} style={{ color: "#3b82f6" }}>
+                &#x27F3;
+              </span>
+              <span>
+                Tap <strong>Reset</strong> to clear all paths and start the
+                puzzle fresh.
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Tips */}
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>Tips</h2>
+        <div className={styles.card}>
+          <ul className={styles.tipList}>
+            <li>
+              <strong>Start with edge dots.</strong> Dots on the border often
+              have limited path options, making them easier to route first.
+            </li>
+            <li>
+              <strong>Think about space.</strong> Every cell must be filled, so
+              consider how paths can cover the whole grid — not just the shortest
+              route.
+            </li>
+            <li>
+              <strong>Work on adjacent pairs.</strong> Connect dots that are close
+              together first, then fill remaining space with longer paths.
+            </li>
+            <li>
+              <strong>Look for forced moves.</strong> Some cells only have one
+              possible color that can pass through them. Identify those early.
+            </li>
+            <li>
+              <strong>Fewer moves = more stars.</strong> Each completed path
+              counts as one move. Solving efficiently earns you up to 3 stars and
+              bonus XP.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      {/* Game Modes */}
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>Game Modes</h2>
+        <div className={styles.card}>
+          <div className={styles.modeItem}>
+            <h3 className={styles.modeName}>Daily Puzzle</h3>
+            <p className={styles.text}>
+              A new puzzle every day for each grid size. Complete it to build
+              your streak. Tap the mode label below the size selector to switch.
+            </p>
+          </div>
+          <div className={styles.modeItem}>
+            <h3 className={styles.modeName}>Free Play</h3>
+            <p className={styles.text}>
+              Unlimited puzzles to practice at any size. Great for honing your
+              strategy before the daily challenge.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* About */}
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>About</h2>
+        <div className={styles.card}>
+          <p className={styles.text}>
+            FlowGrid is a daily path puzzle game inspired by classic flow-connect
+            puzzles. It is built as a progressive web app — install it to your
+            home screen for the best experience.
+          </p>
+          <p className={styles.text} style={{ marginTop: 8, opacity: 0.5 }}>
+            Created by Matt Atencio.
+          </p>
+        </div>
+      </section>
+
+      {/* Back Button */}
+      <div className={styles.backRow}>
+        <Link href="/" className={styles.backBtn}>
+          Back to Game
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -37,6 +37,10 @@ export const metadata = {
     description:
       "Connect color pairs on a grid without crossing paths.",
   },
+  icons: {
+    icon: "/icon.svg",
+    apple: "/icon.svg",
+  },
 };
 
 export const viewport = {

--- a/components/FlowGrid.jsx
+++ b/components/FlowGrid.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
+import Link from "next/link";
 import { getDailyPuzzle, getPuzzle, PUZZLES } from "@/data/puzzles";
 import styles from "./FlowGrid.module.css";
 
@@ -529,6 +530,9 @@ export default function FlowGrid() {
       <header className={styles.header}>
         <h1 className={styles.title}>FlowGrid</h1>
         <div className={styles.headerRight}>
+          <Link href="/help" className={styles.guideLink} title="Guide">
+            GUIDE
+          </Link>
           <button
             className={styles.iconBtn}
             onClick={() => setShowOnboarding(true)}

--- a/components/FlowGrid.module.css
+++ b/components/FlowGrid.module.css
@@ -35,6 +35,25 @@
   gap: 4px;
 }
 
+.guideLink {
+  font-family: var(--font-outfit), sans-serif;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 1.5px;
+  color: rgba(255, 255, 255, 0.35);
+  text-decoration: none;
+  padding: 4px 10px;
+  border-radius: 8px;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+}
+
+.guideLink:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.7);
+}
+
 .iconBtn {
   background: none;
   border: none;

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0a0a14"/>
+      <stop offset="100%" stop-color="#07070f"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="512" height="512" rx="96" fill="url(#bg)"/>
+
+  <!-- Grid lines -->
+  <g stroke="rgba(255,255,255,0.06)" stroke-width="2">
+    <!-- Vertical -->
+    <line x1="128" y1="64" x2="128" y2="448"/>
+    <line x1="208" y1="64" x2="208" y2="448"/>
+    <line x1="288" y1="64" x2="288" y2="448"/>
+    <line x1="368" y1="64" x2="368" y2="448"/>
+    <!-- Horizontal -->
+    <line x1="64" y1="128" x2="448" y2="128"/>
+    <line x1="64" y1="208" x2="448" y2="208"/>
+    <line x1="64" y1="288" x2="448" y2="288"/>
+    <line x1="64" y1="368" x2="448" y2="368"/>
+  </g>
+
+  <!-- Grid border -->
+  <rect x="64" y="64" width="384" height="384" rx="16" fill="none" stroke="rgba(255,255,255,0.08)" stroke-width="3"/>
+
+  <!-- Green flow path: top-left to bottom-right area -->
+  <path d="M 96 96 L 96 176 L 96 256 L 176 256 L 256 256"
+        stroke="#22c55e" stroke-width="28" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.7"/>
+  <!-- Green endpoints -->
+  <circle cx="96" cy="96" r="22" fill="#22c55e" opacity="1">
+    <animate attributeName="opacity" values="0.85;1;0.85" dur="3s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="96" cy="96" r="22" fill="none" stroke="#22c55e" stroke-width="0" opacity="0.4">
+    <animate attributeName="r" values="22;30;22" dur="3s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.4;0;0.4" dur="3s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="256" cy="256" r="22" fill="#22c55e" opacity="1"/>
+
+  <!-- Red flow path: top-right to mid-right -->
+  <path d="M 416 96 L 336 96 L 336 176 L 336 256 L 416 256 L 416 336"
+        stroke="#ef4444" stroke-width="28" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.7"/>
+  <!-- Red endpoints -->
+  <circle cx="416" cy="96" r="22" fill="#ef4444" opacity="1"/>
+  <circle cx="416" cy="336" r="22" fill="#ef4444" opacity="1">
+    <animate attributeName="opacity" values="0.85;1;0.85" dur="3s" repeatCount="indefinite" begin="1s"/>
+  </circle>
+
+  <!-- Blue flow path: bottom-left area -->
+  <path d="M 96 416 L 176 416 L 176 336 L 256 336 L 256 416 L 336 416 L 416 416"
+        stroke="#3b82f6" stroke-width="28" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.7"/>
+  <!-- Blue endpoints -->
+  <circle cx="96" cy="416" r="22" fill="#3b82f6" opacity="1"/>
+  <circle cx="416" cy="416" r="22" fill="#3b82f6" opacity="1">
+    <animate attributeName="opacity" values="0.85;1;0.85" dur="3s" repeatCount="indefinite" begin="2s"/>
+  </circle>
+
+  <!-- Yellow flow: small connection -->
+  <path d="M 176 96 L 256 96 L 256 176 L 176 176 L 96 176"
+        stroke="#eab308" stroke-width="28" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.7"/>
+  <!-- Yellow endpoints (reusing the path start/end positions that make sense on the grid) -->
+  <circle cx="176" cy="96" r="22" fill="#eab308" opacity="1"/>
+  <circle cx="96" cy="176" r="22" fill="#eab308" opacity="1"/>
+
+  <!-- Purple flow -->
+  <path d="M 96 336 L 176 336 L 176 256"
+        stroke="#a855f7" stroke-width="28" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.7"/>
+  <circle cx="96" cy="336" r="22" fill="#a855f7" opacity="1"/>
+  <circle cx="176" cy="256" r="22" fill="#a855f7" opacity="1"/>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,7 +8,8 @@
   "theme_color": "#22c55e",
   "orientation": "portrait",
   "icons": [
-    { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "/icon-512.png", "sizes": "512x512", "type": "image/png" }
+    { "src": "/icon.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any maskable" },
+    { "src": "/icon.svg", "sizes": "192x192", "type": "image/svg+xml", "purpose": "any maskable" },
+    { "src": "/icon.svg", "sizes": "512x512", "type": "image/svg+xml", "purpose": "any maskable" }
   ]
 }


### PR DESCRIPTION
## Summary
- **G-02 PWA Icons**: Replace broken 1x1 PNG icon stubs with a polished SVG icon featuring colored flow paths on a dark grid. Update `manifest.json` to reference the SVG with `"purpose": "any maskable"`. Add `icons` metadata (icon + apple-touch-icon) to `layout.js`.
- **G-03 Help Page**: Create `/help` route with How to Play instructions, Tips, Game Modes, and About sections, all styled to match the game's dark theme. Add a "GUIDE" link in the game header.

## Test plan
- [ ] Verify the SVG icon renders correctly in browser tab and PWA install prompt
- [ ] Confirm manifest.json is valid and icons load on mobile home screen
- [ ] Navigate to /help and verify all sections render with correct styling
- [ ] Click "Back to Game" on help page to return to the main game
- [ ] Verify the "GUIDE" link appears in the game header and navigates to /help
- [ ] Run `npm run build -- --webpack` to confirm clean production build

Closes MattAtencio/flowgrid#1
Closes MattAtencio/flowgrid#2

🤖 Generated with [Claude Code](https://claude.com/claude-code)